### PR TITLE
fix: support Keycloak 26.3.1 and resolve API changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <keycloak.version>26.0.0</keycloak.version>
+        <keycloak.version>26.3.1</keycloak.version>
         <spotbugs.version>4.8.3.1</spotbugs.version>
 
         <jib-maven-plugin.version>3.4.1</jib-maven-plugin.version>

--- a/src/main/java/nl/first8/keycloak/broker/saml/SAMLEndpoint.java
+++ b/src/main/java/nl/first8/keycloak/broker/saml/SAMLEndpoint.java
@@ -295,10 +295,9 @@ public class SAMLEndpoint {
                 }
             }
 
-            if (requestAbstractType instanceof LogoutRequestType) {
+            if (requestAbstractType instanceof LogoutRequestType logout) {
                 logger.debug("** logout request");
                 event.event(EventType.LOGOUT);
-                LogoutRequestType logout = (LogoutRequestType) requestAbstractType;
                 return logoutRequest(logout, relayState);
 
             } else {
@@ -315,7 +314,7 @@ public class SAMLEndpoint {
                 session.sessions().getUserSessionByBrokerUserIdStream(realm, brokerUserId)
                         .filter(userSession -> userSession.getState() != UserSessionModel.State.LOGGING_OUT &&
                                 userSession.getState() != UserSessionModel.State.LOGGED_OUT)
-                        .collect(Collectors.toList()) // collect to avoid concurrent modification as backchannelLogout removes the user sessions.
+                        .toList() // collect to avoid concurrent modification as backchannelLogout removes the user sessions.
                         .forEach(processLogout(ref));
                 request = ref.get();
 
@@ -414,11 +413,14 @@ public class SAMLEndpoint {
                 if (!isSuccessfulSamlResponse(responseType)) {
                     String statusMessage = responseType.getStatus() == null || responseType.getStatus().getStatusMessage() == null ? Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR : responseType.getStatus().getStatusMessage();
                     logger.errorf("Not a successful SamlResponse: %s", statusMessage);
-                    return callback.error(statusMessage);
+                    var identityProviderModel = session.identityProviders().getByAlias(config.getAlias());
+                    return callback.error(identityProviderModel, statusMessage);
+
                 }
                 if (responseType.getAssertions() == null || responseType.getAssertions().isEmpty()) {
                     logger.error("No Assertions found");
-                    return callback.error(Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR);
+                    var identityProviderModel = session.identityProviders().getByAlias(config.getAlias());
+                    return callback.error(identityProviderModel, Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR);
                 }
 
                 boolean assertionIsEncrypted = AssertionUtil.isAssertionEncrypted(responseType);
@@ -444,7 +446,7 @@ public class SAMLEndpoint {
                     /* We verify the assertion using original document to handle cases where the IdP
                     includes whitespace and/or newlines inside tags. */
                     logger.debug("Verify and get assertion!");
-                    assertionElement = DocumentUtil.getElement(holder.getSamlDocument(), new QName(JBossSAMLConstants.ASSERTION.get()));
+                    assertionElement = DocumentUtil.getElement(holder.getSamlDocument(), new QName(Objects.requireNonNull(JBossSAMLConstants.ASSERTION.get())));
                 }
 
                 // Validate the response Issuer
@@ -598,7 +600,7 @@ public class SAMLEndpoint {
                     .searchClientsByAttributes(realm, Collections.singletonMap(SamlProtocol.SAML_IDP_INITIATED_SSO_URL_NAME, clientUrlName), 0, 1)
                     .findFirst();
 
-            if (!oClient.isPresent()) {
+            if (oClient.isEmpty()) {
                 event.error(Errors.CLIENT_NOT_FOUND);
                 Response response = ErrorPage.error(session, null, Response.Status.BAD_REQUEST, Messages.CLIENT_NOT_FOUND);
                 throw new WebApplicationException(response);
@@ -771,8 +773,7 @@ public class SAMLEndpoint {
 
         @Override
         protected void verifySignature(String key, SAMLDocumentHolder documentHolder) throws VerificationException {
-            if ((!containsUnencryptedSignature(documentHolder)) && (documentHolder.getSamlObject() instanceof ResponseType)) {
-                ResponseType responseType = (ResponseType) documentHolder.getSamlObject();
+            if ((!containsUnencryptedSignature(documentHolder)) && (documentHolder.getSamlObject() instanceof ResponseType responseType)) {
                 List<ResponseType.RTChoiceType> assertions = responseType.getAssertions();
                 if (!assertions.isEmpty()) {
                     // Only relax verification if the response is an authnresponse and contains (encrypted/plaintext) assertion.

--- a/src/main/java/nl/first8/keycloak/broker/saml/SAMLEndpoint.java
+++ b/src/main/java/nl/first8/keycloak/broker/saml/SAMLEndpoint.java
@@ -71,7 +71,6 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 public class SAMLEndpoint {
     protected static final Logger logger = Logger.getLogger(SAMLEndpoint.class);

--- a/src/main/java/nl/first8/keycloak/services/resources/IdentityBrokerService.java
+++ b/src/main/java/nl/first8/keycloak/services/resources/IdentityBrokerService.java
@@ -52,7 +52,6 @@ import org.keycloak.services.managers.*;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.services.resources.LoginActionsService;
 import org.keycloak.services.resources.SessionCodeChecks;
-import org.keycloak.services.resources.account.AccountConsole;
 import org.keycloak.services.util.AuthenticationFlowURLHelper;
 import org.keycloak.services.util.BrowserHistoryHelper;
 import org.keycloak.services.util.CacheControlUtil;
@@ -83,6 +82,8 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
     private static final String LINKING_IDENTITY_PROVIDER = "LINKING_IDENTITY_PROVIDER";
 
     private static final Logger logger = Logger.getLogger(org.keycloak.services.resources.IdentityBrokerService.class);
+
+    public static final String ACCOUNT_MGMT_FORWARDED_ERROR = "ACCOUNT_MGMT_FORWARDED_ERROR";
 
     private final RealmModel realmModel;
 
@@ -144,8 +145,8 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
     /**
      * Closes off CORS preflight requests for account linking
      *
-     * @param providerAlias
-     * @return
+     * @param providerAlias alias
+     * @return http response
      */
     @OPTIONS
     @Path("/{provider_alias}/link")
@@ -191,7 +192,6 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
             return Response.status(302).location(builder.build()).build();
         }
 
-        cookieResult.getSession();
         event.session(cookieResult.getSession());
         event.user(cookieResult.getUser());
         event.detail(Details.USERNAME, cookieResult.getUser().getUsername());
@@ -241,8 +241,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
             }
         }
 
-
-        IdentityProviderModel identityProviderModel = realmModel.getIdentityProviderByAlias(providerAlias);
+        var identityProviderModel = session.identityProviders().getByAlias(providerAlias);
         if (identityProviderModel == null) {
             event.error(Errors.UNKNOWN_IDENTITY_PROVIDER);
             UriBuilder builder = UriBuilder.fromUri(redirectUri)
@@ -279,7 +278,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
         event.success();
 
         try {
-            IdentityProvider<?> identityProvider = getIdentityProvider(session, realmModel, providerAlias);
+            var identityProvider = getIdentityProvider(session, providerAlias);
             Response response = identityProvider.performLogin(createAuthenticationRequest(identityProvider, providerAlias, clientSessionCode));
 
             if (response != null) {
@@ -330,14 +329,14 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
 
             ClientSessionCode<AuthenticationSessionModel> clientSessionCode = new ClientSessionCode<>(session, realmModel, authSession);
             clientSessionCode.setAction(AuthenticationSessionModel.Action.AUTHENTICATE.name());
-            IdentityProviderModel identityProviderModel = realmModel.getIdentityProviderByAlias(providerAlias);
+            var identityProviderModel = session.identityProviders().getByAlias(providerAlias);
             if (identityProviderModel == null) {
                 throw new IdentityBrokerException("Identity Provider [" + providerAlias + "] not found.");
             }
             if (identityProviderModel.isLinkOnly()) {
                 throw new IdentityBrokerException("Identity Provider [" + providerAlias + "] is not allowed to perform a login.");
             }
-            if (clientSessionCode != null && clientSessionCode.getClientSession() != null && loginHint != null) {
+            if (clientSessionCode.getClientSession() != null && loginHint != null) {
                 clientSessionCode.getClientSession().setClientNote(OIDCLoginProtocol.LOGIN_HINT_PARAM, loginHint);
             }
 
@@ -383,15 +382,12 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
 
     @Path("{provider_alias}/endpoint")
     public Object getEndpoint(@PathParam("provider_alias") String providerAlias) {
-        IdentityProvider identityProvider;
-
         try {
-            identityProvider = getIdentityProvider(session, realmModel, providerAlias);
+            var identityProvider = getIdentityProvider(session, providerAlias);
+            return identityProvider.callback(realmModel, this, event);
         } catch (IdentityBrokerException e) {
             throw new NotFoundException(e.getMessage());
         }
-
-        return identityProvider.callback(realmModel, this, event);
     }
 
     @Path("{provider_alias}/token")
@@ -439,7 +435,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
 
                 }
 
-                IdentityProvider identityProvider = getIdentityProvider(session, realmModel, providerAlias);
+                var identityProvider = getIdentityProvider(session, providerAlias);
                 IdentityProviderModel identityProviderConfig = getIdentityProviderConfig(providerAlias);
 
                 if (identityProviderConfig.isStoreToken()) {
@@ -671,7 +667,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
             }
 
 
-            String isRegisteredNewUser = authSession.getAuthNote(AbstractIdpAuthenticator.BROKER_REGISTERED_NEW_USER);
+            String isRegisteredNewUser = authSession.getAuthNote(AbstractIdentityProvider.BROKER_REGISTERED_NEW_USER);
             if (Boolean.parseBoolean(isRegisteredNewUser)) {
 
                 logger.debugf("Registered new user '%s' after first login with identity provider '%s'. Identity provider username is '%s' . ", federatedUser.getUsername(), providerAlias, context.getUsername());
@@ -684,7 +680,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
                     target.importNewUser(session, realmModel, federatedUser, mapper, context);
                 });
 
-                if (context.getIdpConfig().isTrustEmail() && !Validation.isBlank(federatedUser.getEmail()) && !Boolean.parseBoolean(authSession.getAuthNote(AbstractIdpAuthenticator.UPDATE_PROFILE_EMAIL_CHANGED))) {
+                if (context.getIdpConfig().isTrustEmail() && !Validation.isBlank(federatedUser.getEmail()) && !Boolean.parseBoolean(authSession.getAuthNote(AbstractIdentityProvider.UPDATE_PROFILE_EMAIL_CHANGED))) {
                     logger.debugf("Email verified automatically after registration of user '%s' through Identity provider '%s' ", federatedUser.getUsername(), context.getIdpConfig().getAlias());
                     federatedUser.setEmailVerified(true);
                 }
@@ -865,7 +861,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
     }
 
     @Override
-    public Response error(String message) {
+    public Response error(IdentityProviderModel idpConfig, String message) {
         AuthenticationSessionModel authSession = session.getContext().getAuthenticationSession();
 
         Response accountManagementFailedLinking = checkAccountManagementFailedLinking(authSession, message);
@@ -880,7 +876,6 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
 
         return browserAuthentication(authSession, message);
     }
-
 
     private boolean shouldPerformAccountLinking(AuthenticationSessionModel authSession, UserSessionModel userSession, String providerAlias) {
         String noteFromSession = authSession.getAuthNote(LINKING_IDENTITY_PROVIDER);
@@ -1024,7 +1019,8 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
     private void setEmail(BrokeredIdentityContext context, UserModel federatedUser, String newEmail) {
         federatedUser.setEmail(newEmail);
         // change email verified depending on if it is trusted or not
-        if (context.getIdpConfig().isTrustEmail() && !Boolean.parseBoolean(context.getAuthenticationSession().getAuthNote(AbstractIdpAuthenticator.UPDATE_PROFILE_EMAIL_CHANGED))) {
+        var note = context.getAuthenticationSession().getAuthNote(AbstractIdentityProvider.UPDATE_PROFILE_EMAIL_CHANGED);
+        if (context.getIdpConfig().isTrustEmail() && !Boolean.parseBoolean(note)) {
             logger.tracef("Email verified automatically after updating user '%s' through Identity provider '%s' ", federatedUser.getUsername(), context.getIdpConfig().getAlias());
             federatedUser.setEmailVerified(true);
         } else {
@@ -1154,7 +1150,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
                     .setHttpHeaders(headers)
                     .setUriInfo(session.getContext().getUri())
                     .setEventBuilder(event);
-            return protocol.sendError(authSession, error);
+            return protocol.sendError(authSession, error, message);
         }
         return null;
     }
@@ -1196,8 +1192,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
 
         fireErrorEvent(message, throwable);
 
-        if (throwable != null && throwable instanceof WebApplicationException) {
-            WebApplicationException webEx = (WebApplicationException) throwable;
+        if (throwable instanceof WebApplicationException webEx) {
             return webEx.getResponse();
         }
 
@@ -1210,7 +1205,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
         FormMessage errorMessage = new FormMessage(message, parameters);
         try {
             String serializedError = JsonSerialization.writeValueAsString(errorMessage);
-            authSession.setAuthNote(AccountConsole.ACCOUNT_MGMT_FORWARDED_ERROR_NOTE, serializedError);
+            authSession.setAuthNote(ACCOUNT_MGMT_FORWARDED_ERROR, serializedError);
         } catch (IOException ioe) {
             throw new RuntimeException(ioe);
         }
@@ -1261,20 +1256,17 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
         throw ErrorResponse.error(message, Response.Status.NOT_FOUND);
     }
 
-    public static IdentityProvider<?> getIdentityProvider(KeycloakSession session, RealmModel realm, String alias) {
-        IdentityProviderModel identityProviderModel = realm.getIdentityProviderByAlias(alias);
-
-        if (identityProviderModel != null) {
-            IdentityProviderFactory<?> providerFactory = getIdentityProviderFactory(session, identityProviderModel);
-
-            if (providerFactory == null) {
-                throw new IdentityBrokerException("Could not find factory for identity provider [" + alias + "].");
-            }
-
-            return providerFactory.create(session, identityProviderModel);
+    public static IdentityProvider<?> getIdentityProvider(KeycloakSession session, String alias) {
+        var identityProviderModel = session.identityProviders().getByAlias(alias);
+        if (identityProviderModel == null) {
+            throw new IdentityBrokerException("Identity Provider [" + alias + "] not found.");
         }
 
-        throw new IdentityBrokerException("Identity Provider [" + alias + "] not found.");
+        var providerFactory = getIdentityProviderFactory(session, identityProviderModel);
+        if (providerFactory == null) {
+            throw new IdentityBrokerException("Could not find factory for identity provider [" + alias + "].");
+        }
+        return providerFactory.create(session, identityProviderModel);
     }
 
     public static IdentityProviderFactory<?> getIdentityProviderFactory(KeycloakSession session, IdentityProviderModel model) {
@@ -1287,7 +1279,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
     }
 
     private IdentityProviderModel getIdentityProviderConfig(String providerAlias) {
-        IdentityProviderModel model = this.realmModel.getIdentityProviderByAlias(providerAlias);
+        var model = session.identityProviders().getByAlias(providerAlias);
         if (model == null) {
             throw new IdentityBrokerException("Configuration for identity provider [" + providerAlias + "] not found.");
         }


### PR DESCRIPTION
- Updated Keycloak version to 26.3.1
- Fixed build issues related to sendError method signature
- Updated instanceof checks and replaced legacy APIs (e.g., toList, var usage)
- Minor refactoring for clarity and compatibility

Builds successfully with Keycloak 26.3.1